### PR TITLE
Don’t quote rpm-spec-font-lock-keywords

### DIFF
--- a/rpm-spec-mode.el
+++ b/rpm-spec-mode.el
@@ -601,7 +601,8 @@ value returned by function `user-mail-address'."
 
 
 (defvar rpm-spec-font-lock-keywords
-  `((cons rpm-section-regexp rpm-spec-section-face)
+  (list
+   (cons rpm-section-regexp rpm-spec-section-face)
    '("%[a-zA-Z0-9_]+" 0 rpm-spec-macro-face)
    (cons (concat "^" rpm-obsolete-tags-regexp "\\(\([a-zA-Z0-9,_]+\)\\)[ \t]*:")
          '((1 'rpm-spec-obsolete-tag-face)


### PR DESCRIPTION
Without this, I get the following error in Emacs 29, which causes font-locking to fail:

```
Error during redisplay: (jit-lock-function 1) signaled (wrong-number-of-arguments #<subr cons> 1)
```