### PR TITLE
Replace list->string with mapconcat

### DIFF
--- a/rpm-spec-mode.el
+++ b/rpm-spec-mode.el
@@ -1106,12 +1106,7 @@ leave point at previous location."
 			   "\"")
 		   buildoptions)))))
 
-  (progn
-    (defun list->string (lst)
-      (if (cdr lst)
-	  (concat (car lst) " " (list->string (cdr lst)))
-	(car lst)))
-    (compilation-start (list->string (cons rpm-spec-build-command buildoptions)) 'rpmbuild-mode))
+  (compilation-start (mapconcat #'identity (cons rpm-spec-build-command buildoptions) " ") 'rpmbuild-mode)
 
   (if (and rpm-spec-sign-gpg (not rpm-no-gpg))
       (let ((build-proc (get-buffer-process


### PR DESCRIPTION
Currently, when byte-compiling with Emacs 29.4, this warning is issued:
```
In end of data:
rpm-spec-mode.el:1112:34: Warning: the function ‘list->string’ is not known to be defined.
```
The same warning is issued into the `*Warnings*` buffer when loading rpm-spec-mode.el.  The issue is that the recursive function is not defined at the top level.  Explicit recursion is unnecessary, since mapconcat does the job.