### PR TITLE
fix: Allow editing spec file without rpm shell being available

### DIFF
--- a/rpm-spec-mode.el
+++ b/rpm-spec-mode.el
@@ -808,7 +808,7 @@ with no args, if that value is non-nil."
   ;; FIXME: set `sh-ancestors' list based on '%_buildshell'.
   ;; call a custom version of `sh--guess-shell' which compares against
   ;; the macro.
-  (sh-set-shell "rpm" nil nil)
+  (ignore-errors (sh-set-shell "rpm" nil nil))
   (rpm-spec-mode-imenu-setup))
 
 (defun rpm-command-filter (process string)


### PR DESCRIPTION
#### Before

<img width="706" height="307" alt="2026-02-17 17 07 05" src="https://github.com/user-attachments/assets/a940e243-7311-4a9a-97ad-607e8a76b324" />

#### After (everything is correctly loaded)

<img width="686" height="309" alt="2026-02-17 17 07 27" src="https://github.com/user-attachments/assets/e1c22f98-75a8-4dfd-ab15-bd8bc9742106" />
